### PR TITLE
Fix function definition void

### DIFF
--- a/auto-compile.el
+++ b/auto-compile.el
@@ -630,7 +630,7 @@ pretend the byte code file exists.")
 
 (defun auto-compile--byte-compile-file (file)
   (let ((after-change-major-mode-hook
-         (list 'global-font-lock-mode-enable-in-buffer))
+         (list 'global-font-lock-mode-enable-in-buffers))
         (prog-mode-hook nil)
         (emacs-lisp-mode-hook nil))
     (byte-compile-file file)))


### PR DESCRIPTION
4a951af6b186ce86d324460d6629bc0ed391f482 introduced a symbol function definition void message printed to \*Messages\* due to a misspelling.

```
run-hooks: Symbol’s function definition is void: global-font-lock-mode-enable-in-buffer
```

This PR is the fix